### PR TITLE
Remove DEFAULT_ID in favour of classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,17 +167,15 @@ export type AutocompleteAction = {
 You can use something like [popper.js](https://popper.js.org/) to ensure that the autocomplete suggestions stay in the right place on scroll or simply an abolutely positioned `<div>` in some cases is sufficient.
 
 ```ts
-import { DEFAULT_ID } from 'prosemirror-autocomplete';
-
 function placeSuggestion(open: boolean) {
   suggestion.style.display = open ? 'block' : 'none';
-  const rect = document.getElementById(DEFAULT_ID).getBoundingClientRect();
+  const rect = document.getElementsByClassName('autocomplete')[0].getBoundingClientRect();
   suggestion.style.top = `${rect.top + rect.height}px`;
   suggestion.style.left = `${rect.left}px`;
 }
 ```
 
-If you don't want to use the `DEFAULT_ID` provided (which is `'autocomplete'`) then you can provide your own for any trigger:
+If you don't want to use the class provided (which is `'autocomplete'`) or have multiple on the page, then you can provide your own for any trigger:
 
 ```ts
 const options: Options = {
@@ -195,8 +193,8 @@ const options: Options = {
 This will allow you to specify styling of the wrapped decoration (which is a `<span>`). This can be different based on the trigger type. For example, in the above example you can use a css rule to style the inline span, this is what is done in [the demo](./demo/index.html):
 
 ```css
-/* The default ID for the decoration. Override with `decorationAttrs: { id: 'myId' }`  */
-#autocomplete {
+/* The default decoration class. Override with `decorationAttrs: { class: 'myClass' }` */
+.autocomplete {
   border: 1px solid #333;
   border-radius: 2px 2px 0 0;
   border-bottom-color: white;

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The library does not provide a user interface beyond the [demo code](./demo/inde
 ```ts
 import { AutocompleteAction, KEEP_OPEN } from 'prosemirror-autocomplete';
 
-export function reducer(action: AutocompleteAction): boolean {
+export function reducer(action: AutocompleteAction): boolean | KEEP_OPEN {
   switch (action.kind) {
     case ActionKind.open:
       handleSearch(action.search);

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ There are a few other packages that offer similar functionality:
 - [prosemirror-suggestions](https://github.com/quartzy/prosemirror-suggestions)
 - [prosemirror-mentions](https://github.com/joelewis/prosemirror-mentions)
 - [prosemirror-suggest](https://github.com/remirror/remirror/tree/next/packages/prosemirror-suggest)
+- [@tiptap/suggestion](https://www.npmjs.com/package/@tiptap/suggestion)
 
 `prosemirror-suggestions` is similar in that it does not provide a UI, if you want a simple UI out of the box you can look at `prosemirror-mentions`. All three of these libraries trigger based on RegExp and leave the decorations in the state. This is similar to how Twitter works, but is undesirable in writing longer documents where you want to dismiss the suggestions with an escape and not see them again in that area.
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -115,7 +115,6 @@
       </p>
       <div><code id="info"></code></div>
       <div id="editor"></div>
-      <div id="editor2"></div>
       <p>
         Source code and documentation are
         <a href="https://github.com/curvenote/prosemirror-autocomplete">on GitHub</a>.

--- a/demo/index.html
+++ b/demo/index.html
@@ -48,14 +48,12 @@
         margin-right: 8px;
       }
       /* The default ID for the decoration, can override with decorationAttrs = { id: 'something' }  */
-      #autocomplete {
+      .autocomplete {
+        color: blue;
         border: 1px solid #333;
         border-radius: 2px 2px 0 0;
         border-bottom-color: white;
         padding: 2px 5px;
-      }
-      .autocomplete {
-        color: blue;
       }
       .command {
         color: red;

--- a/demo/index.html
+++ b/demo/index.html
@@ -115,6 +115,7 @@
       </p>
       <div><code id="info"></code></div>
       <div id="editor"></div>
+      <div id="editor2"></div>
       <p>
         Source code and documentation are
         <a href="https://github.com/curvenote/prosemirror-autocomplete">on GitHub</a>.

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -8,6 +8,7 @@ import autocomplete, { Options } from '../src';
 import { reducer } from './reducer';
 
 const editor = document.querySelector('#editor') as HTMLDivElement;
+const editor2 = document.querySelector('#editor2') as HTMLDivElement;
 const content = document.querySelector('#content') as HTMLDivElement;
 
 const options: Options = {
@@ -26,6 +27,13 @@ const options: Options = {
 };
 
 (window as any).view = new EditorView(editor, {
+  state: EditorState.create({
+    doc: DOMParser.fromSchema(schema).parse(content),
+    plugins: [...autocomplete(options), ...exampleSetup({ schema, menuBar: false })],
+  }),
+});
+
+(window as any).view2 = new EditorView(editor2, {
   state: EditorState.create({
     doc: DOMParser.fromSchema(schema).parse(content),
     plugins: [...autocomplete(options), ...exampleSetup({ schema, menuBar: false })],

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -4,11 +4,10 @@ import { EditorView } from 'prosemirror-view';
 import { DOMParser } from 'prosemirror-model';
 import { schema } from 'prosemirror-schema-basic';
 import { exampleSetup } from 'prosemirror-example-setup';
-import autocomplete, { Options } from '../src';
+import { autocomplete, Options } from '../src';
 import { reducer } from './reducer';
 
 const editor = document.querySelector('#editor') as HTMLDivElement;
-const editor2 = document.querySelector('#editor2') as HTMLDivElement;
 const content = document.querySelector('#content') as HTMLDivElement;
 
 const options: Options = {
@@ -27,13 +26,6 @@ const options: Options = {
 };
 
 (window as any).view = new EditorView(editor, {
-  state: EditorState.create({
-    doc: DOMParser.fromSchema(schema).parse(content),
-    plugins: [...autocomplete(options), ...exampleSetup({ schema, menuBar: false })],
-  }),
-});
-
-(window as any).view2 = new EditorView(editor2, {
   state: EditorState.create({
     doc: DOMParser.fromSchema(schema).parse(content),
     plugins: [...autocomplete(options), ...exampleSetup({ schema, menuBar: false })],

--- a/demo/reducer.ts
+++ b/demo/reducer.ts
@@ -1,5 +1,5 @@
 import { EditorView } from 'prosemirror-view';
-import { ActionKind, AutocompleteAction, DEFAULT_ID, FromTo } from '../src';
+import { ActionKind, AutocompleteAction, AUTOCOMPLETE, FromTo } from '../src';
 import { closeAutocomplete } from '../src/actions';
 
 const suggestion = document.querySelector('#suggestion') as HTMLDivElement;
@@ -20,7 +20,7 @@ function setInfo(action: AutocompleteAction) {
 
 function placeSuggestion() {
   suggestion.style.display = picker.open ? 'block' : 'none';
-  const rect = document.getElementById(DEFAULT_ID)?.getBoundingClientRect();
+  const rect = document.getElementsByClassName(AUTOCOMPLETE)[0]?.getBoundingClientRect();
   if (!rect) return;
   suggestion.style.top = `${rect.top + rect.height}px`;
   suggestion.style.left = `${rect.left}px`;

--- a/demo/reducer.ts
+++ b/demo/reducer.ts
@@ -1,5 +1,5 @@
 import { EditorView } from 'prosemirror-view';
-import { ActionKind, AutocompleteAction, AUTOCOMPLETE, FromTo } from '../src';
+import { ActionKind, AutocompleteAction, FromTo } from '../src';
 import { closeAutocomplete } from '../src/actions';
 
 const suggestion = document.querySelector('#suggestion') as HTMLDivElement;
@@ -20,7 +20,7 @@ function setInfo(action: AutocompleteAction) {
 
 function placeSuggestion() {
   suggestion.style.display = picker.open ? 'block' : 'none';
-  const rect = document.getElementsByClassName(AUTOCOMPLETE)[0]?.getBoundingClientRect();
+  const rect = document.getElementsByClassName('autocomplete')[0]?.getBoundingClientRect();
   if (!rect) return;
   suggestion.style.top = `${rect.top + rect.height}px`;
   suggestion.style.left = `${rect.left}px`;

--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -12,7 +12,7 @@ import {
   ActionKind,
   AutocompleteState,
 } from './types';
-import { DEFAULT_DECO_ATTRS, inSuggestion, pluginKey } from './utils';
+import { inSuggestion, pluginKey, AUTOCOMPLETE } from './utils';
 
 const inactiveAutocompleteState: AutocompleteState = {
   active: false,
@@ -51,13 +51,13 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
     view() {
       return {
         update: (view, prevState) => {
-          // Add a blur handler to close the autocomplete
-          const dom = view.dom as Element & { autocompleteFocusAdded: boolean };
+          // Add a focus handler to close the autocomplete decoration
+          // Handles the case when coming back to an editor
+          const dom = view.dom as Element & { autocompleteFocusAdded: true };
           if (!dom.autocompleteFocusAdded) {
             view.dom.addEventListener('focus', () => {
-              if (plugin.getState(view.state).active) {
-                closeAutocomplete(view);
-              }
+              if (!plugin.getState(view.state).active) return;
+              closeAutocomplete(view);
             });
             dom.autocompleteFocusAdded = true;
           }
@@ -90,7 +90,10 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
           const { trigger, filter, type } = meta;
           const from = tr.selection.from - trigger.length - (filter?.length ?? 0);
           const to = tr.selection.from;
-          const attrs = { ...DEFAULT_DECO_ATTRS, ...type?.decorationAttrs };
+          const className = type?.decorationAttrs?.class
+            ? [AUTOCOMPLETE, type?.decorationAttrs?.class].join(' ')
+            : AUTOCOMPLETE;
+          const attrs = { ...type?.decorationAttrs, class: className };
           const deco = Decoration.inline(from, to, attrs, {
             inclusiveStart: false,
             inclusiveEnd: true,

--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -51,17 +51,6 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
     view() {
       return {
         update: (view, prevState) => {
-          // Add a focus handler to close the autocomplete decoration
-          // Handles the case when coming back to an editor
-          const dom = view.dom as Element & { autocompleteFocusAdded: true };
-          if (!dom.autocompleteFocusAdded) {
-            view.dom.addEventListener('focus', () => {
-              if (!plugin.getState(view.state).active) return;
-              closeAutocomplete(view);
-            });
-            dom.autocompleteFocusAdded = true;
-          }
-
           const prev = plugin.getState(prevState) as ActiveAutocompleteState;
           const next = plugin.getState(view.state) as ActiveAutocompleteState;
 

--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -12,7 +12,7 @@ import {
   ActionKind,
   AutocompleteState,
 } from './types';
-import { inSuggestion, pluginKey, AUTOCOMPLETE } from './utils';
+import { inSuggestion, pluginKey } from './utils';
 
 const inactiveAutocompleteState: AutocompleteState = {
   active: false,
@@ -80,8 +80,8 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
           const from = tr.selection.from - trigger.length - (filter?.length ?? 0);
           const to = tr.selection.from;
           const className = type?.decorationAttrs?.class
-            ? [AUTOCOMPLETE, type?.decorationAttrs?.class].join(' ')
-            : AUTOCOMPLETE;
+            ? ['autocomplete', type?.decorationAttrs?.class].join(' ')
+            : 'autocomplete';
           const attrs = { ...type?.decorationAttrs, class: className };
           const deco = Decoration.inline(from, to, attrs, {
             inclusiveStart: false,

--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -51,6 +51,17 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
     view() {
       return {
         update: (view, prevState) => {
+          // Add a blur handler to close the autocomplete
+          const dom = view.dom as Element & { autocompleteFocusAdded: boolean };
+          if (!dom.autocompleteFocusAdded) {
+            view.dom.addEventListener('focus', () => {
+              if (plugin.getState(view.state).active) {
+                closeAutocomplete(view);
+              }
+            });
+            dom.autocompleteFocusAdded = true;
+          }
+
           const prev = plugin.getState(prevState) as ActiveAutocompleteState;
           const next = plugin.getState(view.state) as ActiveAutocompleteState;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,7 @@
 import { PluginKey, Selection } from 'prosemirror-state';
 import { DecorationSet } from 'prosemirror-view';
 
-export const AUTOCOMPLETE = 'autocomplete';
-export const pluginKey = new PluginKey(AUTOCOMPLETE);
+export const pluginKey = new PluginKey('autocomplete');
 
 export function inSuggestion(selection: Selection, decorations: DecorationSet) {
   return decorations.find(selection.from, selection.to).length > 0;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { PluginKey, Selection } from 'prosemirror-state';
 import { DecorationSet } from 'prosemirror-view';
 
 export const DEFAULT_ID = 'autocomplete';
-export const DEFAULT_DECO_ATTRS = { id: DEFAULT_ID, class: DEFAULT_ID };
+export const DEFAULT_DECO_ATTRS = { class: DEFAULT_ID };
 
 export const pluginKey = new PluginKey(DEFAULT_ID);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,8 @@
 import { PluginKey, Selection } from 'prosemirror-state';
 import { DecorationSet } from 'prosemirror-view';
 
-export const DEFAULT_ID = 'autocomplete';
-export const DEFAULT_DECO_ATTRS = { class: DEFAULT_ID };
-
-export const pluginKey = new PluginKey(DEFAULT_ID);
+export const AUTOCOMPLETE = 'autocomplete';
+export const pluginKey = new PluginKey(AUTOCOMPLETE);
 
 export function inSuggestion(selection: Selection, decorations: DecorationSet) {
   return decorations.find(selection.from, selection.to).length > 0;


### PR DESCRIPTION
There may be multiple autocomplete elements on the page at once, this removes the reliance on ID and uses class. Editors can look to the most recently selected view to get the correct autocomplete span.

See #3 